### PR TITLE
raise kernel load addr and slip stack under kernel on both 32bit and 64bit

### DIFF
--- a/broadcom/boot.s
+++ b/broadcom/boot.s
@@ -40,7 +40,7 @@ reset:
     stmia r1!,{r2,r3,r4,r5,r6,r7,r8,r9}
 
     ;@ Disable interrupts
-    cpsid aif 
+    cpsid aif
 
     ;@ Set the stack pointer for the different modes
     ;@ Switch to FIQ mode
@@ -63,14 +63,14 @@ reset:
     ldr sp, =_undef_stack
     sub sp, sp, #8
 
-    ;@ Switch to system mode and set the stack pointer to 240MB. This
-    ;@ assumes 256MB total ram and 16MB for the GPU.
+    ;@ Switch to system mode and set the stack pointer to 1MB. This
+    ;@ assumes kernel_address=0x100000 in config.txt and link.ld agreeing
     cps #0x1f
-    ldr sp, =_ld_ram_end
+    ldr sp, =_start
     sub sp, sp, #8
 
-    ;@ Set VBAR to 0x8000
-    mov r0,#0x8000
+    ;@ Set VBAR to _start
+    ldr r0, =_start
     mcr p15, 0, r0, c12, c0, 0
 
     ;@ Clear the BSS section

--- a/broadcom/link.ld
+++ b/broadcom/link.ld
@@ -1,14 +1,13 @@
 
 MEMORY
 {
-    /* Kernel load address for ARM11 is 0x8000 */
-    READONLY (rx): ORIGIN = 0x8000, LENGTH = 2016K
-    RAM (rw): ORIGIN = 0x200000, LENGTH = 254M 
+    /* Kernel load address set in ports/broadcom/config.txt */
+    READONLY (rx): ORIGIN = 0x100000, LENGTH = 2016K
+    RAM (rw): ORIGIN = 0x300000, LENGTH = 200M
 }
 
 SECTIONS
 {
-    . = 0x8000;     
     .text : {
         KEEP(*(.text.boot))
         *(.text .text.* .gnu.linkonce.t*)

--- a/broadcom/link8.ld
+++ b/broadcom/link8.ld
@@ -1,14 +1,13 @@
 
 MEMORY
 {
-    /* Kernel load address for AArch64 is 0x80000 */
-    READONLY (rx): ORIGIN = 0x80000, LENGTH = 1536K
+    /* Kernel load address set in ports/broadcom/config.txt */
+    READONLY (rx): ORIGIN = 0x100000, LENGTH = 1536K
     RAM (rw): ORIGIN = 0x200000, LENGTH = 1022M 
 }
 
 SECTIONS
 {
-    . = 0x80000;     
     .text : {
         KEEP(*(.text.boot))
         *(.text .text.* .gnu.linkonce.t*)

--- a/broadcom/mmu.c
+++ b/broadcom/mmu.c
@@ -43,14 +43,11 @@ STRICT_ALIGN void setup_mmu_flat_map(void) {
                       MM_DESCRIPTOR_SHARED_DEVICE |
                       MM_DESCRIPTOR_ACCESS_READ_WRITE |
                       MM_DESCRIPTOR_EXECUTE_NEVER;
-    level_1_table[0] = 0x00000000 | 
-                       code;
-    level_1_table[1] = (1 << 20) | 
-                       code;
+    level_1_table[0] = 0x00000000 | data;
+    level_1_table[1] = (1 << 20) | code;
     // TODO: Adjust for 256MB vs 512MB ram.
     for (size_t i = 2; i < 16; i++) {
-        level_1_table[i] = (i << 20) |
-                            data;
+        level_1_table[i] = (i << 20) | data;
     }
     // Supersections take up 16 entries in the table but in the cached TLB they
     // only take one entry.


### PR DESCRIPTION
the submodule changes for https://github.com/adafruit/circuitpython/pull/8305

the changes to how this handles the stack, rely on having `kernel_address=0x100000` in `config.txt`, and make both 32bit and 64bit behave the same way