### PR TITLE
Create svd/gen directory in gen_svd.py (if it doesn't exist)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v2
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ${{ env.pythonLocation }}
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}

--- a/gen_svd.py
+++ b/gen_svd.py
@@ -15,6 +15,8 @@ chips = pathlib.Path("svd/chips")
 gen = pathlib.Path("svd/gen")
 bcm_gen = pathlib.Path("broadcom/gen")
 
+gen.mkdir()
+
 bcm2711_altfunc = [[None] * 6 for i in range(58)]
 bcm2837_altfunc = [[None] * 6 for i in range(54)]
 

--- a/gen_svd.py
+++ b/gen_svd.py
@@ -15,7 +15,7 @@ chips = pathlib.Path("svd/chips")
 gen = pathlib.Path("svd/gen")
 bcm_gen = pathlib.Path("broadcom/gen")
 
-gen.mkdir()
+gen.mkdir(exist_ok=True)
 
 bcm2711_altfunc = [[None] * 6 for i in range(58)]
 bcm2837_altfunc = [[None] * 6 for i in range(54)]


### PR DESCRIPTION
Fixes `FileNotFoundError`s when the files are generated:

```
FileNotFoundError: [Errno 2] No such file or directory: 'svd/gen/bcm2711_lpa.svd'
```