### PR TITLE
Fixed bcm283x gpio pull functions

### DIFF
--- a/broadcom/gpio.c
+++ b/broadcom/gpio.c
@@ -16,6 +16,7 @@ BP_Function_Enum FSEL_VALUES[6] = {
     GPIO_FUNCTION_ALT5
 };
 
+#if BCM_VERSION == 2711
 BP_PULL_Enum gpio_get_pull(uint8_t pin_number) {
     volatile uint32_t* pupd = &GPIO->GPIO_PUP_PDN_CNTRL_REG0;
     return (pupd[pin_number / 16] >> ((pin_number % 16) * 2)) & 0x3;
@@ -28,6 +29,7 @@ void gpio_set_pull(uint8_t pin_number, BP_PULL_Enum pull) {
     uint32_t current = pupd[pin_number / 16];
     pupd[pin_number / 16] = (current & ~mask) | (pull & 0x3) << shift;
 }
+#endif
 
 BP_Function_Enum gpio_get_function(uint8_t pin_number) {
     volatile uint32_t* fsel = &GPIO->GPFSEL0;

--- a/broadcom/gpio.h
+++ b/broadcom/gpio.h
@@ -16,11 +16,13 @@ typedef enum {
 // Map the alt number to the actual value.
 extern BP_Function_Enum FSEL_VALUES[6];
 
+
 BP_Function_Enum gpio_get_function(uint8_t pin_number);
 void gpio_set_function(uint8_t pin_number, BP_Function_Enum function);
+#if BCM_VERSION == 2711
 BP_PULL_Enum gpio_get_pull(uint8_t pin_number);
 void gpio_set_pull(uint8_t pin_number, BP_PULL_Enum pull);
-BP_PULL_Enum gpio_get_pull(uint8_t pin_number);
+#endif
 
 bool gpio_get_value(uint8_t pin_number);
 void gpio_set_value(uint8_t pin_number, bool value);

--- a/svd/chips/bcm2835.svd.jinja
+++ b/svd/chips/bcm2835.svd.jinja
@@ -30,7 +30,7 @@
         {{ bcm_cm.peripheral("CM_PCM", peripheral_base + 0x101098)}}
         {{ svd.derived_peripheral("CM_PWM", peripheral_base + 0x1010a0, "CM_PCM") }}
 
-        {%- import "peripherals/gpio.svd.jinja" as gpio %}
+        {%- import "peripherals/bcm283x_gpio.svd.jinja" as gpio %}
         {{ gpio.peripheral("GPIO", peripheral_base + 0x200000, altfunc)}}
 
         {%- import "peripherals/bcm_system_timer.svd.jinja" as bcm_system_timer %}

--- a/svd/chips/bcm2837.svd.jinja
+++ b/svd/chips/bcm2837.svd.jinja
@@ -26,7 +26,7 @@
         {{ bcm_cm.peripheral("CM_PCM", peripheral_base + 0x101098)}}
         {{ svd.derived_peripheral("CM_PWM", peripheral_base + 0x1010a0, "CM_PCM") }}
 
-        {%- import "peripherals/gpio.svd.jinja" as gpio %}
+        {%- import "peripherals/bcm283x_gpio.svd.jinja" as gpio %}
         {{ gpio.peripheral("GPIO", peripheral_base + 0x200000, altfunc)}}
 
         {%- import "peripherals/bcm_system_timer.svd.jinja" as bcm_system_timer %}

--- a/svd/peripherals/bcm283x_gpio.svd.jinja
+++ b/svd/peripherals/bcm283x_gpio.svd.jinja
@@ -1,0 +1,530 @@
+{% macro peripheral(name, base_address, altfunc, interrupt_offset=0) -%}
+        <peripheral>
+            <name>{{ name }}</name>
+            <description>Pin level and mux control</description>
+            <baseAddress>{{ "0x{:x}".format(base_address) }}</baseAddress>
+            <addressBlock>
+                <offset>0</offset>
+                <size>0xF4</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <interrupt>
+                <name>GPIO0</name>
+                <description>Interrupt from bank 0</description>
+                <value>{{ interrupt_offset + 49 }}</value>
+            </interrupt>
+            <interrupt>
+                <name>GPIO1</name>
+                <description>Interrupt from bank 1</description>
+                <value>{{ interrupt_offset + 50 }}</value>
+            </interrupt>
+            <interrupt>
+                <name>GPIO2</name>
+                <description>Interrupt from bank 2</description>
+                <value>{{ interrupt_offset + 51 }}</value>
+            </interrupt>
+            <interrupt>
+                <name>GPIO</name>
+                <description>OR of all GPIO interrupts</description>
+                <value>{{ interrupt_offset + 52 }}</value>
+            </interrupt>
+            <registers>
+                <register>
+                    <name>GPFSEL0</name>
+                    <description>GPIO Function Select 0</description>
+                    <addressOffset>0x00</addressOffset>
+                    {% macro fsel_fields(pin_offset, pin_count=10) -%}
+                    <fields>
+                        {% for i in range(0, pin_count) %}
+                        <field>
+                            <name>FSEL{{ pin_offset + i }}</name>
+                            <description>Function Select {{ pin_offset + i }}</description>
+                            <bitRange>[{{ 3 * i + 2 }}:{{ 3 * i }}]</bitRange>
+                            <access>read-write</access>
+                            <enumeratedValues>
+                                <usage>read-write</usage>
+                                <enumeratedValue>
+                                    <name>INPUT</name>
+                                    <description>Pin is an input</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>OUTPUT</name>
+                                    <description>Pin is an output</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                                {% for bits in (4, 5, 6, 7, 3, 2) %}
+                                {% if altfunc[pin_offset + i][loop.index0] %}
+                                <enumeratedValue>
+                                    <name>{{ altfunc[pin_offset + i][loop.index0] }}</name>
+                                    <description>Pin is connected to {{ altfunc[pin_offset + i][loop.index0] }}</description>
+                                    <value>{{ bits }}</value>
+                                </enumeratedValue>
+                                {% else %}
+                                <enumeratedValue>
+                                    <name>RESERVED{{ loop.index0 }}</name>
+                                    <description>Alt function {{ loop.index0 }} reserved</description>
+                                    <value>{{ bits }}</value>
+                                </enumeratedValue>
+                                {% endif %}
+                                {% endfor %}
+                            </enumeratedValues>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                    {% endmacro %}
+                    {{ fsel_fields(0) }}
+                </register>
+                <register>
+                    <name>GPFSEL1</name>
+                    <description>GPIO Function Select 1</description>
+                    <addressOffset>0x04</addressOffset>
+                    {{ fsel_fields(10) }}
+                </register>
+                <register>
+                    <name>GPFSEL2</name>
+                    <description>GPIO Function Select 2</description>
+                    <addressOffset>0x08</addressOffset>
+                    {{ fsel_fields(20) }}
+                </register>
+                <register>
+                    <name>GPFSEL3</name>
+                    <description>GPIO Function Select 3</description>
+                    <addressOffset>0x0c</addressOffset>
+                    {{ fsel_fields(30) }}
+                </register>
+                <register>
+                    <name>GPFSEL4</name>
+                    <description>GPIO Function Select 4</description>
+                    <addressOffset>0x10</addressOffset>
+                    {{ fsel_fields(40) }}
+                </register>
+                <register>
+                    <name>GPFSEL5</name>
+                    <description>GPIO Function Select 5</description>
+                    <addressOffset>0x14</addressOffset>
+                    {{ fsel_fields(50, (altfunc | length - 50)) }}
+                </register>
+                <register>
+                    <name>GPSET0</name>
+                    <description>GPIO Pin Output Set 0</description>
+                    <addressOffset>0x1c</addressOffset>
+                    <access>write-only</access>
+                    <modifiedWriteValues>oneToSet</modifiedWriteValues>
+                    <fields>
+                        {% for i in range(0, 32) %}
+                        <field>
+                            <name>SET{{ i }}</name>
+                            <description>Set {{ i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPSET1</name>
+                    <description>GPIO Pin Output Set 1</description>
+                    <addressOffset>0x20</addressOffset>
+                    <access>write-only</access>
+                    <modifiedWriteValues>oneToSet</modifiedWriteValues>
+                    <fields>
+                        {% for i in range(0, (altfunc | length - 32)) %}
+                        <field>
+                            <name>SET{{ 32 + i }}</name>
+                            <description>Set {{ 32 + i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPCLR0</name>
+                    <description>GPIO Pin Output Clear 0</description>
+                    <addressOffset>0x28</addressOffset>
+                    <access>write-only</access>
+                    <modifiedWriteValues>oneToClear</modifiedWriteValues>
+                    <fields>
+                        {% for i in range(0, 32) %}
+                        <field>
+                            <name>CLR{{ i }}</name>
+                            <description>Clear {{ i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPCLR1</name>
+                    <description>GPIO Pin Output Clear 1</description>
+                    <addressOffset>0x2c</addressOffset>
+                    <access>write-only</access>
+                    <modifiedWriteValues>oneToClear</modifiedWriteValues>
+                    <fields>
+                        {% for i in range(0, (altfunc | length - 32)) %}
+                        <field>
+                            <name>CLR{{ 32 + i }}</name>
+                            <description>Clear {{ 32 + i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPLEV0</name>
+                    <description>GPIO Pin Level 0</description>
+                    <addressOffset>0x34</addressOffset>
+                    <access>read-only</access>
+                    <fields>
+                        {% for i in range(0, 32) %}
+                        <field>
+                            <name>LEV{{ i }}</name>
+                            <description>Level {{ i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPLEV1</name>
+                    <description>GPIO Pin Level 1</description>
+                    <addressOffset>0x38</addressOffset>
+                    <access>read-only</access>
+                    <fields>
+                        {% for i in range(0, (altfunc | length - 32)) %}
+                        <field>
+                            <name>LEV{{ 32 + i }}</name>
+                            <description>Level {{ 32 + i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+  
+                <register>
+                    <name>GPEDS0</name>
+                    <description>GPIO Pin Event Detect Status 0</description>
+                    <addressOffset>0x40</addressOffset>
+                    <access>read-write</access>
+                    <modifiedWriteValues>oneToClear</modifiedWriteValues>
+                    <fields>
+                        {% for i in range(0, 32) %}
+                        <field>
+                            <name>EDS{{ i }}</name>
+                            <description>Event detected {{ i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPEDS1</name>
+                    <description>GPIO Pin Event Detect Status 1</description>
+                    <addressOffset>0x44</addressOffset>
+                    <access>read-write</access>
+                    <modifiedWriteValues>oneToClear</modifiedWriteValues>
+                    <fields>
+                        {% for i in range(0, (altfunc | length - 32)) %}
+                        <field>
+                            <name>EDS{{ 32 + i }}</name>
+                            <description>Event detected {{ 32 + i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPREN0</name>
+                    <description>GPIO Pin Rising Edge Detect Enable 0</description>
+                    <addressOffset>0x4c</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        {% for i in range(0, 32) %}
+                        <field>
+                            <name>REN{{ i }}</name>
+                            <description>Rising edge enabled {{ i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPREN1</name>
+                    <description>GPIO Pin Rising Edge Detect Enable 1</description>
+                    <addressOffset>0x50</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        {% for i in range(0, (altfunc | length - 32)) %}
+                        <field>
+                            <name>REN{{ 32 + i }}</name>
+                            <description>Rising edge enabled {{ 32 + i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPFEN0</name>
+                    <description>GPIO Pin Falling Edge Detect Enable 0</description>
+                    <addressOffset>0x58</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        {% for i in range(0, 32) %}
+                        <field>
+                            <name>FEN{{ i }}</name>
+                            <description>Falling edge enabled {{ i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+
+                <register>
+                    <name>GPFEN1</name>
+                    <description>GPIO Pin Falling Edge Detect Enable 1</description>
+                    <addressOffset>0x5c</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        {% for i in range(0, (altfunc | length - 32)) %}
+                        <field>
+                            <name>FEN{{ 32 + i }}</name>
+                            <description>Falling edge enabled {{ 32 + i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPHEN0</name>
+                    <description>GPIO Pin High Detect Enable 0</description>
+                    <addressOffset>0x64</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        {% for i in range(0, 32) %}
+                        <field>
+                            <name>HEN{{ i }}</name>
+                            <description>High detect enabled {{ i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPHEN1</name>
+                    <description>GPIO Pin High Detect Enable 1</description>
+                    <addressOffset>0x68</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        {% for i in range(0, (altfunc | length - 32)) %}
+                        <field>
+                            <name>HEN{{ 32 + i }}</name>
+                            <description>High detect enabled {{ 32 + i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPLEN0</name>
+                    <description>GPIO Pin Low Detect Enable 0</description>
+                    <addressOffset>0x70</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        {% for i in range(0, 32) %}
+                        <field>
+                            <name>LEN{{ i }}</name>
+                            <description>Low detect enabled {{ i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+
+                <register>
+                    <name>GPLEN1</name>
+                    <description>GPIO Pin Low Detect Enable 1</description>
+                    <addressOffset>0x74</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        {% for i in range(0, (altfunc | length - 32)) %}
+                        <field>
+                            <name>LEN{{ 32 + i }}</name>
+                            <description>Low detect enabled {{ 32 + i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPAREN0</name>
+                    <description>GPIO Pin Async. Rising Edge Detect 0</description>
+                    <addressOffset>0x7c</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        {% for i in range(0, 32) %}
+                        <field>
+                            <name>AREN{{ i }}</name>
+                            <description>Async rising enabled {{ i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPAREN1</name>
+                    <description>GPIO Pin Async. Rising Edge Detect 1</description>
+                    <addressOffset>0x80</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        {% for i in range(0, (altfunc | length - 32)) %}
+                        <field>
+                            <name>AREN{{ 32 + i }}</name>
+                            <description>Async rising enabled {{ 32 + i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPAFEN0</name>
+                    <description>GPIO Pin Async. Falling Edge Detect 0</description>
+                    <addressOffset>0x88</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        {% for i in range(0, 32) %}
+                        <field>
+                            <name>AFEN{{ i }}</name>
+                            <description>Async falling enabled {{ i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPAFEN1</name>
+                    <description>GPIO Pin Async. Falling Edge Detect 1</description>
+                    <addressOffset>0x8c</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        {% for i in range(0, (altfunc | length - 32)) %}
+                        <field>
+                            <name>AFEN{{ 32 + i }}</name>
+                            <description>Async falling enabled {{ 32 + i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>EXTRA_MUX</name>
+                    <description>Undocumented multiplexing bits</description>
+                    <addressOffset>0xD0</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        <field>
+                            <name>SDIO</name>
+                            <description>Switch peripheral connection to undocumented SDIO pins used on Pi 4</description>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>SDHOST</name>
+                                    <description>Connect the newer SD host</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>ARASAN</name>
+                                    <description>Connect Arasan SD/EMMC host</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>GPPUD</name>
+                    <description>GPIO Pin Pull-up/down Enable</description>
+                    <addressOffset>0x94</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        <field>
+                            <name>PUD</name>
+                            <description>GPIO Pin Pull-up/down</description>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <enumeratedValues>
+                                <name>BP_PULL</name>
+                                <usage>read-write</usage>
+                                <headerEnumName>BP_PULL</headerEnumName>
+                                <enumeratedValue>
+                                    <name>NONE</name>
+                                    <description>No pull</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>DOWN</name>
+                                    <description>Pull down</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>UP</name>
+                                    <description>Pull up</description>
+                                    <value>2</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                </register>
+                <register>
+                    <name>GPPUDCLK0</name>
+                    <description>GPIO Pin Pull-up/down Enable Clock 0</description>
+                    <addressOffset>0x98</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        {% for i in range(0, 32) %}
+                        <field>
+                            <name>PUDCLK{{ i }}</name>
+                            <description>Assert Clock on line {{ i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+                <register>
+                    <name>GPPUDCLK1</name>
+                    <description>GPIO Pin Pull-up/down Enable Clock 1</description>
+                    <addressOffset>0x9c</addressOffset>
+                    <access>read-write</access>
+                    <fields>
+                        {% for i in range(0, (altfunc | length - 32)) %}
+                        <field>
+                            <name>PUDCLK{{ 32 + i }}</name>
+                            <description>Assert Clock on line {{ 32 + i }}</description>
+                            <bitOffset>{{ i }}</bitOffset>
+                            <bitWidth>1</bitWidth>
+                        </field>
+                        {% endfor %}
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+{%- endmacro %}

--- a/svd/peripherals/bcm283x_gpio.svd.jinja
+++ b/svd/peripherals/bcm283x_gpio.svd.jinja
@@ -492,6 +492,7 @@
                                 </enumeratedValue>
                             </enumeratedValues>
                         </field>
+                    </fields>
                 </register>
                 <register>
                     <name>GPPUDCLK0</name>


### PR DESCRIPTION
- added a specific bcm283x gpio file (the 2711 and bcm283x's have some different peripherals)
- copied relevant registers from original gpio file to bcm283x._gpio
- added the GPPUD, GPPUDCLK0, and GPPUDCLK1 registers
- Removed gpio_set_pull and gpio_get_pull functions for the bcm283x's as there pull protocol requires the use of both GPPUD and GPPUDCLKn as well as a delay function for proper timing. There is also no way to read the current pull
- updated bcm2835.svd.jinja and bcm2837.svd.jinja to take bcm283x_gipio.svd.jinja instead of gpio.svd.jinja